### PR TITLE
feat: update library to support Zig 0.15.1

### DIFF
--- a/.github/workflows/zig-test.yml
+++ b/.github/workflows/zig-test.yml
@@ -25,5 +25,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: korandoru/setup-zig@v1
         with:
-          zig-version: 0.12.0 # released versions or master
+          zig-version: 0.15.1 # released versions or master
       - run: zig build test

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pub fn build(b: *std.Build) void {
 ```
 Also make sure to add the following to your `build.zig.zon` file:
 ```bash
-zig fetch --save https://github.com/KeithBrown39423/zuid/archive/refs/tags/v2.0.0.tar.gz
+zig fetch --save https://github.com/KeithBrown39423/zuid/archive/refs/tags/v3.0.0.tar.gz
 ```
 
 ## Examples
@@ -52,7 +52,7 @@ const zuid = @import("zuid");
 pub fn main() !void {
     const uuid = zuid.new.v4();
 
-    std.debug.print("UUID: {s}\n", .{ uuid });
+    std.debug.print("UUID: {f}\n", .{ uuid });
 }
 ```
 If you are creating a v3 or v5 UUID, make sure to include the namespace and data.
@@ -63,7 +63,7 @@ const zuid = @import("zuid");
 pub fn main() !void {
     const uuid = zuid.new.v5(zuid.UuidNamespace.URL, "https://example.com");
 
-    std.debug.print("UUID: {s}\n", .{ uuid });
+    std.debug.print("UUID: {f}\n", .{ uuid });
 }
 ```
 You can also get the UUID as an int through `@bitCast`.
@@ -74,13 +74,13 @@ const zuid = @import("zuid");
 pub fn main() !void {
     const uuid = zuid.new.v4();
 
-    std.debug.print("UUID: {s}\n", .{ uuid });
+    std.debug.print("UUID: {f}\n", .{ uuid });
     const uuid_int = @as(u128, @bitCast(uuid));
     std.debug.print("UUID as int: {d}\n", .{ uuid_int });
 
     // or
 
-    std.debug.print("UUID: {d}\n", .{ uuid });
+    std.debug.print("UUID: {f}\n", .{ std.fmt.alt(uuid, .formatDecimal) });
 }
 ```
 

--- a/build.zig
+++ b/build.zig
@@ -10,9 +10,11 @@ pub fn build(b: *std.Build) void {
 
     const test_step = b.step("test", "Run tests for v1, v3, v4, v5, v6, v7, and v8 UUIDs.");
     const tests = b.addTest(.{
-        .root_source_file = b.path("src/testing.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/testing.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
 
     tests.root_module.addImport("zuid", zuid_mod);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,7 @@
 .{
-    .name = "zuid",
-    .version = "2.0.0",
+    .name = .zuid,
+    .fingerprint = 0x891c40f0c98fb697,
+    .version = "3.0.0",
     .paths = .{""},
+    .minimum_zig_version = "0.15.1",
 }

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -8,7 +8,7 @@ test "UUID v1" {
     const version = uuid.version;
     const variant = uuid.variant;
     var urn: [36]u8 = undefined;
-    _ = std.fmt.bufPrint(&urn, "{s}", .{uuid}) catch unreachable;
+    _ = std.fmt.bufPrint(&urn, "{f}", .{uuid}) catch unreachable;
 
     try expect(urn.len == 36);
     try expect(urn[14] == '1' and version == 1);
@@ -27,7 +27,7 @@ test "UUID v3" {
     const version = uuid.version;
     const variant = uuid.variant;
     var urn: [36]u8 = undefined;
-    _ = std.fmt.bufPrint(&urn, "{s}", .{uuid}) catch unreachable;
+    _ = std.fmt.bufPrint(&urn, "{f}", .{uuid}) catch unreachable;
 
     try expect(std.mem.eql(u8, str, &urn));
     try expect(urn.len == 36);
@@ -42,7 +42,7 @@ test "UUID v4" {
     const version = uuid.version;
     const variant = uuid.variant;
     var urn: [36]u8 = undefined;
-    _ = std.fmt.bufPrint(&urn, "{s}", .{uuid}) catch unreachable;
+    _ = std.fmt.bufPrint(&urn, "{f}", .{uuid}) catch unreachable;
 
     try expect(urn.len == 36);
     try expect(urn[14] == '4' and version == 4);
@@ -61,7 +61,7 @@ test "UUID v5" {
     const version = uuid.version;
     const variant = uuid.variant;
     var urn: [36]u8 = undefined;
-    _ = std.fmt.bufPrint(&urn, "{s}", .{uuid}) catch unreachable;
+    _ = std.fmt.bufPrint(&urn, "{f}", .{uuid}) catch unreachable;
 
     try expect(std.mem.eql(u8, str, &urn));
     try expect(urn.len == 36);
@@ -76,7 +76,7 @@ test "UUID v6" {
     const version = uuid.version;
     const variant = uuid.variant;
     var urn: [36]u8 = undefined;
-    _ = std.fmt.bufPrint(&urn, "{s}", .{uuid}) catch unreachable;
+    _ = std.fmt.bufPrint(&urn, "{f}", .{uuid}) catch unreachable;
 
     try expect(urn.len == 36);
     try expect(urn[14] == '6' and version == 6);
@@ -90,7 +90,7 @@ test "UUID v7" {
     const version = uuid.version;
     const variant = uuid.variant;
     var urn: [36]u8 = undefined;
-    _ = std.fmt.bufPrint(&urn, "{s}", .{uuid}) catch unreachable;
+    _ = std.fmt.bufPrint(&urn, "{f}", .{uuid}) catch unreachable;
 
     try expect(urn.len == 36);
     try expect(urn[14] == '7' and version == 7);
@@ -108,7 +108,7 @@ test "UUID v8" {
     const version = uuid.version;
     const variant = uuid.variant;
     var urn: [36]u8 = undefined;
-    _ = std.fmt.bufPrint(&urn, "{s}", .{uuid}) catch unreachable;
+    _ = std.fmt.bufPrint(&urn, "{f}", .{uuid}) catch unreachable;
 
     try expect(urn.len == 36);
     try expect(urn[14] == '8' and version == 8);

--- a/src/zuid.zig
+++ b/src/zuid.zig
@@ -30,47 +30,54 @@ pub const UUID = packed struct {
     set_2: u16,
     set_1: u32,
 
-    pub fn format(self: *const UUID, comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
-        _ = options;
-        if (std.mem.eql(u8, fmt, "s")) {
-            try std.fmt.format(writer, "{x:0>8}-{x:0>4}-{x:0>4}-{x:0>4}-{x:0>12}", .{
-                self.set_1,
-                self.set_2,
-                (self.set_3 & 0x0FFF) | (@as(u16, @intCast(self.version)) << 12),
-                (self.set_4 & 0x3FFF) | (@as(u16, @intCast(self.variant)) << 14),
-                self.set_5,
-            });
-        } else if (std.mem.eql(u8, fmt, "x")) {
-            try std.fmt.format(writer, "{x:0>8}{x:0>4}{x:0>4}{x:0>4}{x:0>12}", .{
-                self.set_1,
-                self.set_2,
-                (self.set_3 & 0x0FFF) | (@as(u16, @intCast(self.version)) << 12),
-                (self.set_4 & 0x3FFF) | (@as(u16, @intCast(self.variant)) << 14),
-                self.set_5,
-            });
-        } else if (std.mem.eql(u8, fmt, "S")) {
-            try std.fmt.format(writer, "{X:0>8}-{X:0>4}-{X:0>4}-{X:0>4}-{X:0>12}", .{
-                self.set_1,
-                self.set_2,
-                (self.set_3 & 0x0FFF) | (@as(u16, @intCast(self.version)) << 12),
-                (self.set_4 & 0x3FFF) | (@as(u16, @intCast(self.variant)) << 14),
-                self.set_5,
-            });
-        } else if (std.mem.eql(u8, fmt, "X")) {
-            try std.fmt.format(writer, "{X:0>8}{X:0>4}{X:0>4}{X:0>4}{X:0>12}", .{
-                self.set_1,
-                self.set_2,
-                (self.set_3 & 0x0FFF) | (@as(u16, @intCast(self.version)) << 12),
-                (self.set_4 & 0x3FFF) | (@as(u16, @intCast(self.variant)) << 14),
-                self.set_5,
-            });
-        } else if (std.mem.eql(u8, fmt, "d")) {
-            try std.fmt.format(writer, "{d}", .{@as(u128, @bitCast(self.*))});
-        } else {
-            var buffer: [16]u8 = undefined;
-            std.mem.writeInt(u128, &buffer, @as(u128, @bitCast(self.*)), .big);
-            try std.fmt.format(writer, "{any}", .{&buffer});
-        }
+    pub fn format(self: UUID, writer: *std.Io.Writer) !void {
+        try writer.print("{x:0>8}-{x:0>4}-{x:0>4}-{x:0>4}-{x:0>12}", .{
+            self.set_1,
+            self.set_2,
+            (self.set_3 & 0x0FFF) | (@as(u16, @intCast(self.version)) << 12),
+            (self.set_4 & 0x3FFF) | (@as(u16, @intCast(self.variant)) << 14),
+            self.set_5,
+        });
+    }
+
+    pub fn formatHex(self: UUID, writer: *std.Io.Writer) !void {
+        try writer.print("{x:0>8}{x:0>4}{x:0>4}{x:0>4}{x:0>12}", .{
+            self.set_1,
+            self.set_2,
+            (self.set_3 & 0x0FFF) | (@as(u16, @intCast(self.version)) << 12),
+            (self.set_4 & 0x3FFF) | (@as(u16, @intCast(self.variant)) << 14),
+            self.set_5,
+        });
+    }
+
+    pub fn formatUpper(self: UUID, writer: *std.Io.Writer) !void {
+        try writer.print("{X:0>8}-{X:0>4}-{X:0>4}-{X:0>4}-{X:0>12}", .{
+            self.set_1,
+            self.set_2,
+            (self.set_3 & 0x0FFF) | (@as(u16, @intCast(self.version)) << 12),
+            (self.set_4 & 0x3FFF) | (@as(u16, @intCast(self.variant)) << 14),
+            self.set_5,
+        });
+    }
+
+    pub fn formatHexUpper(self: UUID, writer: *std.Io.Writer) !void {
+        try writer.print("{X:0>8}{X:0>4}{X:0>4}{X:0>4}{X:0>12}", .{
+            self.set_1,
+            self.set_2,
+            (self.set_3 & 0x0FFF) | (@as(u16, @intCast(self.version)) << 12),
+            (self.set_4 & 0x3FFF) | (@as(u16, @intCast(self.variant)) << 14),
+            self.set_5,
+        });
+    }
+
+    pub fn formatDecimal(self: UUID, writer: *std.Io.Writer) !void {
+        try writer.print("{d}", .{@as(u128, @bitCast(self))});
+    }
+
+    pub fn formatBytes(self: UUID, writer: *std.Io.Writer) !void {
+        var buffer: [16]u8 = undefined;
+        std.mem.writeInt(u128, &buffer, @as(u128, @bitCast(self)), .big);
+        try writer.print("{any}", .{&buffer});
     }
 
     pub fn toArray(self: *const UUID) [16]u8 {


### PR DESCRIPTION
This PR updates the `format` function to support the new writer interface introduced in Zig 0.15.1
- https://ziglang.org/download/0.15.1/release-notes.html#f-Required-to-Call-format-Methods
- https://ziglang.org/download/0.15.1/release-notes.html#Format-Methods-No-Longer-Have-Format-Strings-or-Options